### PR TITLE
Fix segfault

### DIFF
--- a/src/TrGame.cpp
+++ b/src/TrGame.cpp
@@ -7,6 +7,7 @@
 
 TrGame::TrGame() {
   TrData data = TrData::getInstance();
+  m_gameStateTransition = nullptr;
   // exit(0);
 
   // Initialize


### PR DESCRIPTION
Specifically, `m_gameStateTransition` was uninitialized when it got to the if check here: https://github.com/VjiaoBlack/terrain-gen/blob/5bb06b834a083aaa489f15ec56057b16487fa312/src/TrGame.cpp#L166 , so it can be non-zero and pass right through. Then it caused a problem when dereferenced in the next line: https://github.com/VjiaoBlack/terrain-gen/blob/5bb06b834a083aaa489f15ec56057b16487fa312/src/TrGame.cpp#L167

TBH I don't know C++ that well, so there could be a more idiomatic way to do this.