### PR TITLE
Fix warnings (remove typo)

### DIFF
--- a/src/.dir-locals.el
+++ b/src/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((c++-mode
+  (flycheck-clang-language-standard . "c++17")))

--- a/src/TrData/TrData.hpp
+++ b/src/TrData/TrData.hpp
@@ -22,7 +22,7 @@ using namespace std;
 
 // TODO: figure out a way to avoid having to repeat a m_entityTypes map for each
 //       entity type
-static class TrData {
+class TrData {
  public:
   static void loadData();
   static void deleteData();

--- a/src/TrECS/TrItems/TrItem.hpp
+++ b/src/TrECS/TrItems/TrItem.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <utility> #include <utility>
+#include <utility>
 /**
  * TrItem.hpp
  */

--- a/src/TrRenderLoop/TrTransitionLoop.hpp
+++ b/src/TrRenderLoop/TrTransitionLoop.hpp
@@ -7,7 +7,7 @@
 #include "TrRenderLoop.hpp"
 
 #include <memory>
-#include <utility> #include <utility>
+#include <utility>
 class TrTransitionLoop : public TrRenderLoop {
  private:
   shared_ptr<TrRenderLoop> m_target;


### PR DESCRIPTION
@VjiaoBlack you said this is just a typo, right?

Also, this line is giving me a warning: https://github.com/VjiaoBlack/terrain-gen/blob/090de2f0e56395e0afbe7a1c288b412e2e471c18/src/TrData/TrData.hpp#L25

```
src/TrData/TrData.hpp:25:1: warning: 'static' is not
      permitted on a declaration of a type [-Wmissing-declarations]
static class TrData {
^
```

Is this just an experimental C++ feature my compiler doesn't support, or is that also a typo?